### PR TITLE
Add max velocity to mycobot 280 m5 model

### DIFF
--- a/mycobot_description/urdf/mycobot_280_m5/mycobot_280_m5.urdf
+++ b/mycobot_description/urdf/mycobot_280_m5/mycobot_280_m5.urdf
@@ -143,7 +143,7 @@
 
   <joint name="joint2_to_joint1" type="revolute">
     <axis xyz="0 0 1"/>
-    <limit effort = "1000.0" lower = "-2.9321" upper = "2.9321" velocity = "0"/>
+    <limit effort = "1000.0" lower = "-2.9321" upper = "2.9321" velocity = "2.792526803190927"/>
     <parent link="joint1"/>
     <child link="joint2"/>
     <origin xyz= "0 0 0.13156" rpy = "0 0 0"/>  
@@ -152,7 +152,7 @@
 
   <joint name="joint3_to_joint2" type="revolute">
     <axis xyz="0 0 1"/>
-    <limit effort = "1000.0" lower = "-2.4434" upper = "2.4434" velocity = "0"/>
+    <limit effort = "1000.0" lower = "-2.4434" upper = "2.4434" velocity = "2.792526803190927"/>
     <parent link="joint2"/>
     <child link="joint3"/>
     <origin xyz= "0 0  0" rpy = "0 1.5708 -1.5708"/>  
@@ -161,7 +161,7 @@
 
   <joint name="joint4_to_joint3" type="revolute">
     <axis xyz=" 0 0 1"/>
-    <limit effort = "1000.0" lower = "-2.6179" upper = "2.6179" velocity = "0"/>
+    <limit effort = "1000.0" lower = "-2.6179" upper = "2.6179" velocity = "2.792526803190927"/>
     <parent link="joint3"/>
     <child link="joint4"/>
     <origin xyz= "  -0.1104 0 0   " rpy = "0 0 0"/>  
@@ -171,7 +171,7 @@
 
   <joint name="joint5_to_joint4" type="revolute">
     <axis xyz=" 0 0 1"/>
-    <limit effort = "1000.0" lower = "-2.6179" upper = "2.6179" velocity = "0"/>
+    <limit effort = "1000.0" lower = "-2.6179" upper = "2.6179" velocity = "2.792526803190927"/>
     <parent link="joint4"/>
     <child link="joint5"/>
     <origin xyz= "-0.096 0 0.06462" rpy = "0 0 -1.5708"/>  
@@ -179,7 +179,7 @@
 
   <joint name="joint6_to_joint5" type="revolute">
     <axis xyz="0 0 1"/>
-    <limit effort = "1000.0" lower = "-2.7052" upper = "2.7925" velocity = "0"/>
+    <limit effort = "1000.0" lower = "-2.7052" upper = "2.7925" velocity = "2.792526803190927"/>
     <parent link="joint5"/>
     <child link="joint6"/>
     <origin xyz= "0 -0.07318 0" rpy = "1.5708 -1.5708 0"/>  
@@ -187,7 +187,7 @@
 
   <joint name="joint6output_to_joint6" type="revolute">
     <axis xyz="0 0 1"/>
-    <limit effort = "1000.0" lower = "-3.14" upper = "3.14159" velocity = "0"/>
+    <limit effort = "1000.0" lower = "-3.14" upper = "3.14159" velocity = "2.792526803190927"/>
     <parent link="joint6"/>
     <child link="joint6_flange"/>
     <origin xyz= "0 0.0456 0" rpy = "-1.5708 0 0"/>  


### PR DESCRIPTION
### Summary

The URDF model of `mycobot280_m5` sets the velocity limit to `0`, which prevents the robot from moving in simulation.

This pull request fixes the issue by adding an appropriate velocity limit to the URDF model.

### Details

According to the official specification, the maximum joint velocity of the myCobot 280 M5 is **160 degrees per second**.
This value is converted to radians per second and set in the URDF as approximately **2.79 rad/s**.

* Source: https://www.elephantrobotics.com/en/mycobot-280-m5-new-specificatons-en/

### Impact

* Enables proper motion in simulators
* Aligns the URDF model with the official hardware specifications

### Notes

* No changes were made to other dynamics parameters